### PR TITLE
Add language switcher

### DIFF
--- a/_includes/about.html
+++ b/_includes/about.html
@@ -1,4 +1,5 @@
-{% assign about = site.data.about[site.language] %}
+{% assign lang = page.lang | default: site.language %}
+{% assign about = site.data.about[lang] %}
 
 {% if about %}
 <a name="about"></a>

--- a/_includes/experiences.html
+++ b/_includes/experiences.html
@@ -1,4 +1,5 @@
-{% assign experiences = site.data.experience[site.language] %}
+{% assign lang = page.lang | default: site.language %}
+{% assign experiences = site.data.experience[lang] %}
 
 {% if experiences %}
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,8 +1,9 @@
-{% assign experiences = site.data.experience[site.language] %}
-{% assign skills = site.data.skills[site.language] %}
-{% assign publications = site.data.publications[site.language] %}
-{% assign projects = site.data.projects[site.language] %}
-{% assign about = site.data.about[site.language] %}
+{% assign lang = page.lang | default: site.language %}
+{% assign experiences = site.data.experience[lang] %}
+{% assign skills = site.data.skills[lang] %}
+{% assign publications = site.data.publications[lang] %}
+{% assign projects = site.data.projects[lang] %}
+{% assign about = site.data.about[lang] %}
 
 <footer class="footer">
     <div class="text-center">

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,4 +1,5 @@
-{% assign sidebar = site.data.sidebar[site.language] %}
+{% assign lang = page.lang | default: site.language %}
+{% assign sidebar = site.data.sidebar[lang] %}
 
 <div class="sidebar-wrapper">
 
@@ -19,6 +20,8 @@
   </div><!--//profile-container-->
 
   {% include sidebar/contact.html %}
+
+  {% include sidebar/lang-switcher.html %}
 
   {% include sidebar/language.html %}
 

--- a/_includes/sidebar/contact.html
+++ b/_includes/sidebar/contact.html
@@ -1,4 +1,5 @@
-{% assign sidebar = site.data.sidebar[site.language] %}
+{% assign lang = page.lang | default: site.language %}
+{% assign sidebar = site.data.sidebar[lang] %}
 
 <div class="contact-container container-block">
   <ul class="list-unstyled contact-list">

--- a/_includes/sidebar/education.html
+++ b/_includes/sidebar/education.html
@@ -1,4 +1,5 @@
-{% assign education = site.data.education[site.language] %}
+{% assign lang = page.lang | default: site.language %}
+{% assign education = site.data.education[lang] %}
 
 {% if education %}
 

--- a/_includes/sidebar/interests.html
+++ b/_includes/sidebar/interests.html
@@ -1,4 +1,5 @@
-{% assign interests = site.data.sidebar[site.language].interests %}
+{% assign lang = page.lang | default: site.language %}
+{% assign interests = site.data.sidebar[lang].interests %}
 {% if interests %}
 <div class="interests-container container-block">
 

--- a/_includes/sidebar/lang-switcher.html
+++ b/_includes/sidebar/lang-switcher.html
@@ -1,0 +1,8 @@
+{% assign lang = page.lang | default: site.language %}
+<div class="lang-switcher container-block">
+  <h2 class="container-block-title">Language</h2>
+  <ul class="list-unstyled interests-list">
+    <li><a href="{{ site.baseurl }}/">English</a></li>
+    <li><a href="{{ site.baseurl }}/pt/">Português</a></li>
+  </ul>
+</div>

--- a/_includes/sidebar/language.html
+++ b/_includes/sidebar/language.html
@@ -1,4 +1,5 @@
-{% assign languages = site.data.sidebar[site.language].languages %}
+{% assign lang = page.lang | default: site.language %}
+{% assign languages = site.data.sidebar[lang].languages %}
 
 {% if languages %}
 <div class="languages-container container-block">

--- a/_includes/sidebar/sections.html
+++ b/_includes/sidebar/sections.html
@@ -1,6 +1,7 @@
-{% assign experiences = site.data.experience[site.language] %}
-{% assign skills = site.data.skills[site.language] %}
-{% assign about = site.data.about[site.language] %}
+{% assign lang = page.lang | default: site.language %}
+{% assign experiences = site.data.experience[lang] %}
+{% assign skills = site.data.skills[lang] %}
+{% assign about = site.data.about[lang] %}
 
 <div class="sections-container container-block">
 

--- a/_includes/skills.html
+++ b/_includes/skills.html
@@ -1,4 +1,5 @@
-{% assign skills = site.data.skills[site.language] %}
+{% assign lang = page.lang | default: site.language %}
+{% assign skills = site.data.skills[lang] %}
 
 {% if skills %}
 <a name="skills"></a>

--- a/index.markdown
+++ b/index.markdown
@@ -1,5 +1,6 @@
 ---
 layout: default
+lang: en
 ---
 
 {% include about.html %}

--- a/pt/index.markdown
+++ b/pt/index.markdown
@@ -1,0 +1,10 @@
+---
+layout: default
+lang: pt
+---
+
+{% include about.html %}
+
+{% include skills.html %}
+
+{% include experiences.html %}


### PR DESCRIPTION
## Summary
- support per-page language via `lang` front matter
- add Portuguese version of the site
- include a sidebar language switcher

## Testing
- `./build.sh` *(fails: Gem::Net::HTTPClientException 403)*

------
https://chatgpt.com/codex/tasks/task_e_6852b4838dbc8333a99b83035afdca31